### PR TITLE
Migrate font stack from Fraunces/IBM Plex Sans to Noto Sans

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OSS Forums</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -27,11 +27,10 @@ onMounted(() => {
 </template>
 
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Fraunces:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap');
-
 :root {
   color-scheme: light;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: 'Noto Sans', sans-serif;
+  font-optical-sizing: auto;
   background-color: #f4efe5;
   color: #0f172a;
 }

--- a/apps/web/src/components/AppHeader.vue
+++ b/apps/web/src/components/AppHeader.vue
@@ -75,7 +75,7 @@ const auth = useAuthStore()
 }
 
 .brand__text {
-  font-family: 'Fraunces', serif;
+  font-family: 'Noto Sans', sans-serif;
   font-size: 1.25rem;
   letter-spacing: 0.02em;
 }

--- a/apps/web/src/components/CommentComposer.vue
+++ b/apps/web/src/components/CommentComposer.vue
@@ -64,7 +64,7 @@ textarea {
   border-radius: 0.9rem;
   border: 1px solid rgba(15, 23, 42, 0.12);
   padding: 0.85rem 1rem;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: 'Noto Sans', sans-serif;
   font-size: 0.95rem;
   resize: vertical;
 }

--- a/apps/web/src/components/NewPostForm.vue
+++ b/apps/web/src/components/NewPostForm.vue
@@ -72,7 +72,7 @@ textarea {
   border-radius: 1rem;
   border: 1px solid rgba(15, 23, 42, 0.12);
   padding: 1rem;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: 'Noto Sans', sans-serif;
   font-size: 0.95rem;
   resize: vertical;
 }
@@ -87,7 +87,7 @@ input {
   border-radius: 1rem;
   border: 1px solid rgba(15, 23, 42, 0.12);
   padding: 1rem;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: 'Noto Sans', sans-serif;
   font-size: 0.95rem;
 }
 

--- a/apps/web/src/views/ChannelView.vue
+++ b/apps/web/src/views/ChannelView.vue
@@ -123,7 +123,7 @@ const handlePostSubmit = (body: string, title: string) => {
 
 .channel-view__intro h1 {
   margin: 0.3rem 0 0.5rem;
-  font-family: 'Fraunces', serif;
+  font-family: 'Noto Sans', sans-serif;
   font-size: 2.2rem;
 }
 

--- a/apps/web/src/views/ChannelsView.vue
+++ b/apps/web/src/views/ChannelsView.vue
@@ -78,7 +78,7 @@ const handleCreateChannel = (payload: {
 .page-hero h1 {
   font-size: 2.6rem;
   margin: 0 0 1rem;
-  font-family: 'Fraunces', serif;
+  font-family: 'Noto Sans', sans-serif;
 }
 
 .subtitle {

--- a/apps/web/src/views/NotFoundView.vue
+++ b/apps/web/src/views/NotFoundView.vue
@@ -30,7 +30,7 @@
 .not-found h1 {
   margin: 0;
   font-size: 2.2rem;
-  font-family: 'Fraunces', serif;
+  font-family: 'Noto Sans', sans-serif;
 }
 
 .ghost-link {

--- a/apps/web/src/views/PostView.vue
+++ b/apps/web/src/views/PostView.vue
@@ -179,7 +179,7 @@ const handleRemovePost = () => {
 .post-view__title h1 {
   margin: 0 0 0.6rem;
   font-size: 2rem;
-  font-family: 'Fraunces', serif;
+  font-family: 'Noto Sans', sans-serif;
 }
 
 .post-view__meta {

--- a/apps/web/src/views/RegisterView.vue
+++ b/apps/web/src/views/RegisterView.vue
@@ -100,7 +100,7 @@ const submit = async () => {
 header h1 {
   margin: 0 0 0.5rem;
   font-size: 2rem;
-  font-family: 'Fraunces', serif;
+  font-family: 'Noto Sans', sans-serif;
 }
 
 header p {


### PR DESCRIPTION
Replaces all Fraunces (display headings) and IBM Plex Sans (body/inputs) references with Noto Sans via Google Fonts, loaded via preconnect links in index.html with font-optical-sizing enabled at root.